### PR TITLE
Normalize directory upload behavior regardless of trailing slash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 const fs = require("fs");
 const os = require("os");
+const path = require("path");
 const rfs = require("recursive-fs");
 const FormData = require("form-data");
-const basePathConverter = require("base-path-converter");
 const got = require("got");
 
 const isDirectory = async (filepath) => {
@@ -84,7 +84,7 @@ const upload = async (filepath) => {
       for (const file of files) {
         const content = fs.readFileSync(file);
         data.append(`file`, content, {
-          filepath: basePathConverter(filepath, file),
+          filepath: path.join(filepath, path.relative(filepath, file)),
         });
       }
     } else {
@@ -124,7 +124,7 @@ const uploadSubmarine = async (filepath) => {
       for (const file of files) {
         const content = fs.readFileSync(file);
         data.append(`files`, content, {
-          filepath: basePathConverter(filepath, file),
+          filepath: path.join(filepath, path.relative(filepath, file)),
         });
       }
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pinata-upload-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -58,11 +58,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "base-path-converter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base-path-converter/-/base-path-converter-1.0.2.tgz",
-      "integrity": "sha512-51R8JiuXadknn6ouVUteOhDpmI3G5u5GqjruL7bPJpfxUHVgosaO5uPAvRP4FeR4VyyH4sSvsN78Ci6ouoRYqQ=="
     },
     "cacheable-lookup": {
       "version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "base-path-converter": "^1.0.2",
     "commander": "^8.3.0",
     "form-data": "^4.0.0",
     "got": "^11.8.2",


### PR DESCRIPTION
The module base-path-converter was being used to normalize all file paths during directory upload so all files in the directory were listed relative to the directory. However, this module incorrectly handled trailing slashes in the base directory path, for example: `basePathConverter("test/", "test/file")` returned `test`, as did `basePathConverter("test/", "test/other-file")`.

This led to command inputs like `pinata-cli -u awesome-assets/` uploading the entire directory but pinning the hash of a single file inside that directory instead.

This change removes the mentioned module and replaces it with node's own path handling utilities. This should achieve the same functional result, as well as correcting erroneous paths in the upload payload like `test//file.ext` and making it more robust for cross-platform use.

**Testing**

Before this change, uploading the directory `test` with two plain text files `content` and `othecontent` resulted in the following upload payload:

```
----------------------------964170412725699298036318
Content-Disposition: form-data; name="file"; filename="test"
Content-Type: application/octet-stream

some content

----------------------------964170412725699298036318
Content-Disposition: form-data; name="file"; filename="test"
Content-Type: application/octet-stream

some other content

----------------------------964170412725699298036318--
```

After this change, the payload is correct:

```
-------------------------256060110248833717591952
Content-Disposition: form-data; name="file"; filename="test/content"
Content-Type: application/octet-stream

some content

----------------------------256060110248833717591952
Content-Disposition: form-data; name="file"; filename="test/othercontent"
Content-Type: application/octet-stream

some other content

----------------------------256060110248833717591952--
```

Additionally, when running through the CLI index file, we can see that the two commands are now equivalent: 

```
~/pinata-cli main — node index.js -u test/

{ percent: 0, transferred: 0, total: 408 }
{ percent: 0.3872549019607843, transferred: 158, total: 408 }
{ percent: 0.41911764705882354, transferred: 171, total: 408 }
{ percent: 0.42401960784313725, transferred: 173, total: 408 }
{ percent: 0.8112745098039216, transferred: 331, total: 408 }
{ percent: 0.8578431372549019, transferred: 350, total: 408 }
{ percent: 1, transferred: 408, total: 408 }
Pinning, please wait...
{
  IpfsHash: 'QmNr8kcjUkwXNzkTEggqA2vBExzUhUvmzF6YjyrbxmKD4t',
  PinSize: 27,
  Timestamp: '2022-02-01T03:38:31.961Z'
}

~/pinata-cli main — node index.js -u test/

{ percent: 0, transferred: 0, total: 408 }
{ percent: 0.3872549019607843, transferred: 158, total: 408 }
{ percent: 0.41911764705882354, transferred: 171, total: 408 }
{ percent: 0.42401960784313725, transferred: 173, total: 408 }
{ percent: 0.8112745098039216, transferred: 331, total: 408 }
{ percent: 0.8578431372549019, transferred: 350, total: 408 }
{ percent: 1, transferred: 408, total: 408 }
Pinning, please wait...
{
  IpfsHash: 'QmNr8kcjUkwXNzkTEggqA2vBExzUhUvmzF6YjyrbxmKD4t',
  PinSize: 27,
  Timestamp: '2022-02-01T03:38:31.961Z',
  isDuplicate: true
}
```